### PR TITLE
Fix for more than 8 GPUs

### DIFF
--- a/py3nvml/utils.py
+++ b/py3nvml/utils.py
@@ -78,9 +78,9 @@ Proceeding on cpu only..."""
 
     # Flag which gpus we can check
     if gpu_select is None:
-        gpu_check = [True] * 8
+        gpu_check = [True] * numDevices
     else:
-        gpu_check = [False] * 8
+        gpu_check = [False] * numDevices
         try:
             gpu_check[gpu_select] = True
         except TypeError:

--- a/tests/test_py3nvml.py
+++ b/tests/test_py3nvml.py
@@ -32,9 +32,13 @@ def test_grabgpus2():
     assert res == 1
 
 def test_grabgpus3():
+    nvmlInit()
     res = grab_gpus(100)
     assert len(os.environ['CUDA_VISIBLE_DEVICES']) < len(','.join([str(x) for x in range(100)]))
-    assert res <= 8
+    assert res <= nvmlDeviceGetCount()
+
+    nvmlShutdown()
+
 
 def test_grabgpus4():
     res = grab_gpus(5, gpu_select=range(3,8))


### PR DESCRIPTION
grab_gpus failed for me on a system with more than 8 GPUs. My fix is to use the same length (nvmlDeviceGetCount) for for gpu_check and gpu_select, which allows all the GPUs to be grabbed.